### PR TITLE
[Design] Main Page Layout 구현

### DIFF
--- a/client/src/components/common/Footer/Footer.styles.tsx
+++ b/client/src/components/common/Footer/Footer.styles.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import { ColFlex } from '../../../styles/GlobalStyles';
+
+export const FooterContainerWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export const FooterContainerFlex = styled.div`
+  ${ColFlex}
+  width: 100%;
+  max-width: 90vw;
+  position: fixed;
+  bottom: 0;
+`;
+
+export const FooterContent = styled.div`
+  height: 20px;
+  padding: 5px 0;
+  background-color: green;
+`;

--- a/client/src/components/common/Footer/Footer.tsx
+++ b/client/src/components/common/Footer/Footer.tsx
@@ -1,5 +1,19 @@
+import {
+  FooterContainerFlex,
+  FooterContainerWrap,
+  FooterContent,
+} from './Footer.styles';
+
 function Footer() {
-  return <div>푸터입니다</div>;
+  return (
+    <FooterContainerWrap>
+      <FooterContainerFlex>
+        <FooterContent>
+          <h1>푸터</h1>
+        </FooterContent>
+      </FooterContainerFlex>
+    </FooterContainerWrap>
+  );
 }
 
 export default Footer;

--- a/client/src/components/common/Header/Header.styles.tsx
+++ b/client/src/components/common/Header/Header.styles.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { ColFlex } from '../../../styles/GlobalStyles';
+
+export const HeaderContainerWrap = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export const HeaderContainerFlex = styled.div`
+  width: 100%;
+  max-width: 90vw;
+`;
+
+export const HeaderContent = styled.div`
+  ${ColFlex}
+  height: 60px;
+  background-color: red;
+`;

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -1,5 +1,24 @@
+import {
+  Container,
+  ContainerFlex,
+  ContainerWrap,
+} from '../../../styles/Layout';
+import {
+  HeaderContainerFlex,
+  HeaderContainerWrap,
+  HeaderContent,
+} from './Header.styles';
+
 function Header() {
-  return <div>헤더입네다</div>;
+  return (
+    <HeaderContainerWrap>
+      <HeaderContainerFlex>
+        <HeaderContent>
+          <h1>헤더</h1>
+        </HeaderContent>
+      </HeaderContainerFlex>
+    </HeaderContainerWrap>
+  );
 }
 
 export default Header;

--- a/client/src/pages/Main/Main.styles.tsx
+++ b/client/src/pages/Main/Main.styles.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const MainContent = styled.div`
+  height: 100%;
+  background-color: blue;
+  padding: 40px 0;
+  box-sizing: border-box;
+  height: calc(100vh - 60px);
+`;

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -1,5 +1,13 @@
+import { Container, ContainerWrap, Content } from '../../styles/Layout';
+import { MainContent } from './Main.styles';
 function Main() {
-  return <div>메인이다!!!!!????????????!!!</div>;
+  return (
+    <ContainerWrap>
+      <Container>
+        <MainContent>메인</MainContent>
+      </Container>
+    </ContainerWrap>
+  );
 }
 
 export default Main;

--- a/client/src/styles/Layout.tsx
+++ b/client/src/styles/Layout.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
+import { ColFlex } from './GlobalStyles';
 
 /*최상위 컨테이너 */
 export const ContainerWrap = styled.div`
   display: flex;
   justify-content: center;
-  margin: 40px 0;
 `;
 
 /* 컨텐츠 컨테이너 */

--- a/client/src/styles/ResetCss.tsx
+++ b/client/src/styles/ResetCss.tsx
@@ -5,7 +5,15 @@ const ResetCss = css`
   * {
     margin: 0;
     padding: 0;
+
+    //-ms-overflow-style: none; /* 인터넷 익스플로러 */
+    //scrollbar-width: none; /* 파이어폭스 */
   }
+
+  /* *::-webkit-scrollbar {
+    display: none;
+  } */
+
   html,
   body,
   div,


### PR DESCRIPTION
## 📌 개요
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 이슈 번호: #29

## ✨ 개발 내용
메인 페이지 작업 전, 기존에 추가했던 글로벌 component 와 css 를 활용하여 메인 페이지 레이아웃 틀을 구현함

## 🔥 변경 로직(optional)

```javascript
Main.jsx

function Main() {
  return (
    <ContainerWrap>
      <Container>
        <MainContent>메인</MainContent>
      </Container>
    </ContainerWrap>
  );
}
```
```javascript
Header.jsx

function Header() {
  return (
    <HeaderContainerWrap>
      <HeaderContainerFlex>
        <HeaderContent>
          <h1>헤더</h1>
        </HeaderContent>
      </HeaderContainerFlex>
    </HeaderContainerWrap>
  );
}
```
```javascript
Footer.jsx

function Footer() {
  return (
    <FooterContainerWrap>
      <FooterContainerFlex>
        <FooterContent>
          <h1>푸터</h1>
        </FooterContent>
      </FooterContainerFlex>
    </FooterContainerWrap>
  );
}
```
### 📸 스크린샷(optional)
<!-- 관련 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
![image](https://user-images.githubusercontent.com/71073027/223916637-b97834fe-61e9-4599-b42c-586fb7c06465.png)

### 👓 고민사항(optional)
메인 페이지의 컨텐츠들을 화면에 꽉 차게 지정하기가 생각보다 까다로웠음...

