### PR TITLE
[Feat] 로그 시각화를 위한 prometheus 환경 설정 추가

### DIFF
--- a/server/Prometheus.yml
+++ b/server/Prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s # 15초마다 매트릭을 수집 default 1분
+  evaluation_interval: 1m # 1분마다 규칙을 평가 default 1분
+
+  external_labels: # 외부 시스템에 표시할 이 서버의 레이블
+    monitor: 'photoday-monitor'
+
+scrape_configs:
+  - job_name: 'photoday' # 잡 이름
+    metrics_path: '/management/prometheus' # 메트릭을 수집할 path 설정
+    static_configs:
+      - targets: ['host.docker.internal:8080'] # 도커 호스트 를 나타냄 즉 localhost:8080으로 된다.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -74,8 +74,21 @@ mail:
     member:
       registration: Photoday 임시비밀번호 안내 이메일입니다.
 management:
-  endpoint:
+  info:
+    env:
+      enabled: true
   endpoints:
     web:
-      base-path: /application
+      exposure:
+        include: info, health, prometheus
+        exclude:
+      base-path: /management
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: Photoday
 


### PR DESCRIPTION
## 📌 개요
- 이슈 번호: #156

## ✨ 개발 내용
prometheus + grafana 를 이용한 로그 시각화 
로컬에서 실험 완료. EC2 서버에서 실험 예정

## 🔥 변경 로직(optional)
prometheus 환경 설정 추가

### 📸 스크린샷(optional)
<img width="1459" alt="스크린샷 2023-03-23 오후 11 19 52" src="https://user-images.githubusercontent.com/108881135/227233530-29709827-d08b-409b-9679-66ba768ccb16.png">

### 👓 고민사항(optional)

### 📩 전달사항(optional)

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들(optional)
